### PR TITLE
Safer install/uninstall

### DIFF
--- a/automator/imgur-screenshot-upload-template.workflow/Contents/document.wflow
+++ b/automator/imgur-screenshot-upload-template.workflow/Contents/document.wflow
@@ -409,7 +409,7 @@
 	<key>workflowMetaData</key>
 	<dict>
 		<key>folderActionFolderPath</key>
-        <string>${SCREENSHOT_DIR}</string>
+        <string>{SCREENSHOT_DIR}</string>
 		<key>workflowTypeIdentifier</key>
 		<string>com.apple.Automator.folderAction</string>
 	</dict>

--- a/install.sh
+++ b/install.sh
@@ -1,24 +1,33 @@
 #!/bin/bash
 source ./variables.sh
 
-SCREENSHOT_DIR_TO_USE=$(defaults read com.apple.screencapture location)
+# Fail fast for any commands which return an error
+set -e
 
 AUTOMATOR_IMGUR_SCREENSHOT_UPLOAD_TEMPLATE_DIR=./automator/imgur-screenshot-upload-template.workflow
 AUTOMATOR_IMGUR_UPLOAD_TEMPLATE_DIR=./automator/imgur-upload-template.workflow
-
 AUTOMATOR_DOCUMENT_FILE=/Contents/document.wflow
 
+# Determine the directory in which screenshots will be saved
 if [ "x$1" != "x" ]; then
     SCREENSHOT_DIR_TO_USE=$1
-    ./set_screenshot_dir.sh $SCREENSHOT_DIR_TO_USE &> /dev/null
+	./set_screenshot_dir.sh $SCREENSHOT_DIR_TO_USE
+elif ! SCREENSHOT_DIR_TO_USE=$(defaults read com.apple.screencapture location); then
+	# Screenshot dir is OS default by omission of any preference to the contrary
+    echo "screenshot dir default: \"$HOME/Desktop\""
 fi
 
-echo "copying imguru to $IMGURU_INSTALL_PATH"
+if [ -z ${SCREENSHOT_DIR_TO_USE+x} ]; then
+    echo "screenshot dir is: \"$SCREENSHOT_DIR_TO_USE\""
+fi
 
-# copy the binary to upload images
-cp ./imgur-uploader/imguru $IMGURU_INSTALL_PATH
-
-echo "screenshot dir is: \"$SCREENSHOT_DIR_TO_USE\""
+# copy the binary to upload images if it's not already on the PATH
+if IMGURU_EXISTING_PATH=$(which imguru); then
+	echo "existing imguru found $IMGURU_EXISTING_PATH"
+else
+    echo "copying imguru to $IMGURU_INSTALL_PATH"
+    cp ./imgur-uploader/imguru $IMGURU_INSTALL_PATH
+fi
 
 echo "installing..."
 

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,7 @@ if [ "x$1" != "x" ]; then
     ./set_screenshot_dir.sh $SCREENSHOT_DIR_TO_USE
 elif ! SCREENSHOT_DIR_TO_USE=$(defaults read com.apple.screencapture location); then
     # Screenshot dir is OS default by omission of any preference to the contrary
+    echo "com.apple.screencapture location override isn't set - using default screenshot dir"
     SCREENSHOT_DIR_TO_USE=~/Desktop
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -11,21 +11,19 @@ AUTOMATOR_DOCUMENT_FILE=/Contents/document.wflow
 # Determine the directory in which screenshots will be saved
 if [ "x$1" != "x" ]; then
     SCREENSHOT_DIR_TO_USE=$1
-	./set_screenshot_dir.sh $SCREENSHOT_DIR_TO_USE
+    ./set_screenshot_dir.sh $SCREENSHOT_DIR_TO_USE
 elif ! SCREENSHOT_DIR_TO_USE=$(defaults read com.apple.screencapture location); then
-	# Screenshot dir is OS default by omission of any preference to the contrary
-    echo "screenshot dir default: \"$HOME/Desktop\""
+    # Screenshot dir is OS default by omission of any preference to the contrary
+    SCREENSHOT_DIR_TO_USE=~/Desktop
 fi
 
-if [ -z ${SCREENSHOT_DIR_TO_USE+x} ]; then
-    echo "screenshot dir is: \"$SCREENSHOT_DIR_TO_USE\""
-fi
+echo "screenshot dir is: \"$SCREENSHOT_DIR_TO_USE\""
 
 # copy the binary to upload images if it's not already on the PATH
 if IMGURU_EXISTING_PATH=$(which imguru); then
-	echo "existing imguru found $IMGURU_EXISTING_PATH"
+    echo "existing imguru found: $IMGURU_EXISTING_PATH"
 else
-    echo "copying imguru to $IMGURU_INSTALL_PATH"
+    echo "copying imguru to: $IMGURU_INSTALL_PATH"
     cp ./imgur-uploader/imguru $IMGURU_INSTALL_PATH
 fi
 
@@ -35,13 +33,12 @@ echo "installing..."
 cp -r $AUTOMATOR_IMGUR_SCREENSHOT_UPLOAD_TEMPLATE_DIR $AUTOMATOR_IMGUR_SCREENSHOT_UPLOAD_DIR
 cp -r $AUTOMATOR_IMGUR_UPLOAD_TEMPLATE_DIR $AUTOMATOR_IMGUR_UPLOAD_DIR
 
-# alter the copied screenshot automator template to set the screenshot dir
-sed -i '' 's/{SCREENSHOT_DIR}/${SCREENSHOT_DIR_TO_USE}/g' $AUTOMATOR_IMGUR_SCREENSHOT_UPLOAD_DIR$AUTOMATOR_DOCUMENT_FILE
+# replace variable placeholder for the path to the shell executable
+sed -i '' "s|{SHELL}|${SHELL}|g" $AUTOMATOR_IMGUR_SCREENSHOT_UPLOAD_DIR$AUTOMATOR_DOCUMENT_FILE
+sed -i '' "s|{SHELL}|${SHELL}|g" $AUTOMATOR_IMGUR_UPLOAD_DIR$AUTOMATOR_DOCUMENT_FILE
 
-SHELL_PATH=$(echo $SHELL | sed 's/\//\\\//g')
-# set the appropriate shells for both automator scripts
-sed -i '' "s/{SHELL}/${SHELL_PATH}/g" $AUTOMATOR_IMGUR_SCREENSHOT_UPLOAD_DIR$AUTOMATOR_DOCUMENT_FILE
-sed -i '' "s/{SHELL}/${SHELL_PATH}/g" $AUTOMATOR_IMGUR_UPLOAD_DIR$AUTOMATOR_DOCUMENT_FILE
+# replace variable placeholder for the screenshot directory
+sed -i '' "s|{SCREENSHOT_DIR}|${SCREENSHOT_DIR_TO_USE}|g" $AUTOMATOR_IMGUR_SCREENSHOT_UPLOAD_DIR$AUTOMATOR_DOCUMENT_FILE
 
 # now install the automator files
 mkdir -p "$SCREENSHOT_SERVICE_INSTALL_PATH"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 source ./variables.sh
 
-echo "removing services"
+# Fail fast for any commands which return an error
+set -e
 
-rm -r "$UPLOAD_SERVICE_INSTALL_PATH$IMGUR_UPLOAD_WORKFLOW"
-rm -r "$SCREENSHOT_SERVICE_INSTALL_PATH$IMGUR_SCREENSHOT_WORKFLOW"
+echo "removing installed files..."
 
-echo "removing imguru"
-rm $IMGURU_INSTALL_PATH/imguru
+IMGUR_UPLOAD_WORKFLOW_PATH=$UPLOAD_SERVICE_INSTALL_PATH$IMGUR_UPLOAD_WORKFLOW
+IMGUR_SCREENSHOT_WORKFLOW_PATH=$SCREENSHOT_SERVICE_INSTALL_PATH$IMGUR_SCREENSHOT_WORKFLOW
+IMGURU_BINARY_PATH=$IMGURU_INSTALL_PATH/imguru
+
+PATHS=("$IMGUR_UPLOAD_WORKFLOW_PATH" "$IMGUR_SCREENSHOT_WORKFLOW_PATH" "$IMGURU_BINARY_PATH")
+for path in "${PATHS[@]}"; do
+	if [ -e "${path}" ]; then
+		echo "removing \"${path}\""
+		rm -rf "${path}"
+	fi
+done
+
+echo "success"


### PR DESCRIPTION
I had some trouble with the install/uninstall scripts. This pull request fixes a couple of bugs and makes the scripts fail faster with better messaging. That's my intent anyway, let me know what you think.
- Remove extra '$' from upload template for variable
- Use 'set -e' to fail fast on any commands that fail (previously `echo "success"` always executed)
- Use the default (Desktop) if com.apple.screencapture location isn't set (It's not in Yosemite)
- Use '|' over '/' as delimiter for sed involving paths for simpler way to get correct behavior
- Only copy 'imguru' binary if it isn't on the path
- Only delete files if they exist, report the ones that are removed on uninstall
